### PR TITLE
Add Security Patch Policy for Gradle Build Tool

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,8 @@
 Please do not report security issues to the public issue tracker.
 Please send security issues to [security@gradle.com](mailto:security@gradle.com).
 We do our best to get back to you by the end of the next business day.
+
+## Security Patch Policy
+
+For the Gradle Build Tool, it's our intention to fix security issues in our next release.
+We will only backport security fixes to earlier major versions in extenuating circumstances.


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/2515